### PR TITLE
feat: Add credits to Echo account

### DIFF
--- a/src/contexts/echo.tsx
+++ b/src/contexts/echo.tsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect, useCallback } from "react";
 import { EchoContext, type EchoContextValue } from "@/hooks/useEcho";
 import type { EchoUser, EchoBalance } from "@/types/echo";
 import { useEchoClient } from "@/hooks/useEchoClient";
+import { useEchoPayments } from "@/hooks/useEchoPayments";
 
 interface EchoProviderProps {
   children: React.ReactNode;
@@ -176,15 +177,7 @@ export const EchoProvider: React.FC<EchoProviderProps> = ({ children }) => {
     refreshBalance();
   }, [refreshBalance]);
 
-  const createPaymentLink = async (
-    amount: number,
-    description: string,
-    successUrl?: string,
-  ): Promise<string> => {
-    // TODO: Implement payment link creation
-    console.log("Creating payment link:", { amount, description, successUrl });
-    return "";
-  };
+  const { createPaymentLink } = useEchoPayments(echoClient);
 
   const getToken = async (): Promise<string | null> => {
     try {

--- a/src/echo-popup/src/pages/welcome.tsx
+++ b/src/echo-popup/src/pages/welcome.tsx
@@ -1,12 +1,51 @@
-import React from "react";
+import React, { useState } from "react";
 import { EchoSignin } from "@/components/ui/echo-sign-in";
+import { Button } from "@/components/ui/button";
+import { useEcho } from "@/hooks/useEcho";
 
 export const WelcomePage: React.FC = () => {
+  const { isAuthenticated, createPaymentLink } = useEcho();
+  const [isCreatingPayment, setIsCreatingPayment] = useState(false);
+  const [paymentError, setPaymentError] = useState<string | null>(null);
+
+  const handleCreatePaymentLink = async () => {
+    setIsCreatingPayment(true);
+    setPaymentError(null);
+    
+    try {
+      const paymentUrl = await createPaymentLink(
+        1,
+        "Echo Credits Purchase"
+      );
+      
+      // Open payment link in a new tab using Chrome API
+      chrome.tabs.create({ url: paymentUrl });
+    } catch (error) {
+      setPaymentError(error instanceof Error ? error.message : 'Failed to create payment link');
+    } finally {
+      setIsCreatingPayment(false);
+    }
+  };
 
   return (
-    
     <div className="flex flex-col h-full w-full items-center justify-center gap-4">
       <EchoSignin className="w-32 h-12 mb-4" />
+      
+      {isAuthenticated && (
+        <div className="flex flex-col items-center gap-2">
+          <Button 
+            onClick={handleCreatePaymentLink}
+            disabled={isCreatingPayment}
+            variant="default"
+          >
+            {isCreatingPayment ? 'Creating...' : 'Buy Credits'}
+          </Button>
+          
+          {paymentError && (
+            <p className="text-sm text-red-500">{paymentError}</p>
+          )}
+        </div>
+      )}
     </div>
   );
 };

--- a/src/hooks/useEchoPayments.ts
+++ b/src/hooks/useEchoPayments.ts
@@ -1,0 +1,56 @@
+import { EchoClient, parseEchoError } from '@merit-systems/echo-typescript-sdk';
+import { useCallback, useState } from 'react';
+
+export function useEchoPayments(echoClient: EchoClient | null) {
+  const [error, setError] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const createPaymentLink = useCallback(
+    async (
+      amount: number,
+      description?: string,
+      successUrl?: string
+    ): Promise<string> => {
+      if (!echoClient) {
+        throw new Error('Not authenticated');
+      }
+
+      setIsLoading(true);
+      try {
+        // Get active tab URL
+        const tabs = await chrome.tabs.query({ active: true, currentWindow: true });
+        const activeTab = tabs[0];
+        if (!activeTab?.url) {
+          throw new Error('No active tab');
+        }
+
+        const activeTabUrl = new URL(activeTab.url).origin;
+
+        const response = await echoClient.payments.createPaymentLink({
+          amount,
+          description: description || 'Echo Credits',
+          successUrl: successUrl || activeTabUrl,
+        });
+
+        setError(null);
+        return response.paymentLink.url;
+      } catch (err) {
+        const echoError = parseEchoError(
+          err instanceof Error ? err : new Error(String(err)),
+          'creating payment link'
+        );
+        setError(echoError.message);
+        throw echoError;
+      } finally {
+        setIsLoading(false);
+      }
+    },
+    [echoClient]
+  );
+
+  return {
+    createPaymentLink,
+    error,
+    isLoading,
+  };
+}


### PR DESCRIPTION
Not a perfect implementation but at least it works. 

There is some issues with the redirect on success. Right now it just creates a tab to handle the payment. Since it's called from a popup it's hard to go back to that. Going to leave it as is right now, but I think a new window to handle the payment link might help us preserve this. We can generate a success payment link page so that the can close it